### PR TITLE
Update everything_filter.txt

### DIFF
--- a/Chat Filters/everything_filter.txt
+++ b/Chat Filters/everything_filter.txt
@@ -249,7 +249,7 @@ your fake bot
 ^(?:[\p{L}\p{N}][\p{L}\p{N}_ -]{0,11})\s+got\s+pa\p{L}d\s+\d{1,4}\s*[kKmMbB]\b
 ^(?:[\p{L}\p{N}][\p{L}\p{N}_ -]{0,11})\s+pa\p{L}d\s+\d{1,4}\s*[kKmMbB]\b
 \d{3,4}\s*[kK]\s*or\s*\d{2,4}\s*[mM]\s+for\s+(playing|joining|participating)
-(?i)^the\s+person\s+[\w-]{1,12}\s+(?:put\s+\d{1,4}(?:\.\d+)?\s*[kmb]|i\s+didn[’']?t\s+get\s+it\s+right|had\s+the\s+prize\s+\d{1,4}(?:\.\d+)?\s*[kmb]|yes,?\s*i\s*accept\.?\s+\d{1,4}(?:\.\d+)?\s*[kmb])\b
+(?i)^[^\p{L}\p{N}]*the\s+person\s+[\w-]{1,12}\s+(?:put\s+\d{1,4}(?:\.\d+)?\s*[kmb]|i\s+didn[’']?t\s+get\s+it\s+right|had\s+the\s+prize\s+\d{1,4}(?:\.\d+)?\s*[kmb]|yes,?\s*i\s*accept\.?\s+\d{1,4}(?:\.\d+)?\s*[kmb])\b
 ^[\w-]{1,12}\s+add[eé]d\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB]\s+to\s+the\s+p[oö]t\b
 \b\d{1,3}\s*%\s+of\s+od+d[z2]s?\s+f[öo]r(?:\s+[\w-]{1,12})?\b
 \bverified\s*host\b.*\bwins?\b


### PR DESCRIPTION
Harden “The person <user> …” scam regex to catch prefixed characters

- Updated consolidated pattern to tolerate leading punctuation/zero-width characters before “The person …” lines (e.g., stray quotes, ZW chars).
- Keeps support for:
  - put <amount>
  - didn’t get it right
  - had the prize <amount>
  - Yes, I accept. <amount>
- Still matches decimals and K/M/B units with username length ≤12.
- Ensures cases like “The person Zuk-25 put 70.3M” and “The person Zuk-25 Yes,I accept. 140.6M” are filtered.