### PR TITLE
Update everything_filter.txt

### DIFF
--- a/Chat Filters/everything_filter.txt
+++ b/Chat Filters/everything_filter.txt
@@ -253,3 +253,8 @@ your fake bot
 ^[\w-]{1,12}\s+add[eé]d\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB]\s+to\s+the\s+p[oö]t\b
 \b\d{1,3}\s*%\s+of\s+od+d[z2]s?\s+f[öo]r(?:\s+[\w-]{1,12})?\b
 \bverified\s*host\b.*\bwins?\b
+\n(?i)\b(?:wins?|host|casino|jackp\p{L}t)\b.*\b\d{1,4}\s*[kKmMbB]\s+min\b
+(?i)\bcasino\p{L}?\s+is\s+open,?\s+\d{1,4}\s*[kKmMbB]\s+to\s+pl\p{L}y\s+now\b
+(?i)\bverified\s+gam\p{L}\b.*\bplay\s+and\s+win\b
+(?i)\bwin\s+\p{L}{2,}\s+here\b.*\b\d{1,4}\s*[kKmMbB]\s+min\b
+(?i)\bjackp\p{L}t\b


### PR DESCRIPTION
Expand casino/jackpot spam filters

- Added new regex rules to block casino-style spam:
  - “win/host/casino/jackpot … <amount> min”
  - “Casino is open, <amount> to play now”
  - “Verified game … play and win”
  - “Win <word> here … <amount> min”
  - Diacritic variants of “Jackpöt/Jackpot”
- Ensures detection of common lure phrases using “1M Min” thresholds and obfuscations.